### PR TITLE
che #15906 Adding 'che.workspace.stop.role.enabled' property in order to have a possibility to disable the 'OpenShiftStopWorkspaceRoleProvisioner'

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -157,6 +157,10 @@ che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia
 # default 10MB=10485760
 che.workspace.startup_debug_log_limit_bytes=10485760
 
+# If true, 'stop-workspace' role with the edit privileges will be granted to the 'che' ServiceAccount.
+# This configuration is mainly required for workspace idling when the OpenShift OAuth is enabled.
+che.workspace.stop.role.enabled=true
+
 ### Templates
 
 # Folder that contains JSON files with code templates and samples

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/OpenShiftStopWorkspaceRoleProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/OpenShiftStopWorkspaceRoleProvisionerTest.java
@@ -132,7 +132,7 @@ public class OpenShiftStopWorkspaceRoleProvisionerTest {
   public void setUp() throws Exception {
     lenient().when(cheInstallationLocation.getInstallationLocationNamespace()).thenReturn("che");
     stopWorkspaceRoleProvisioner =
-        new OpenShiftStopWorkspaceRoleProvisioner(clientFactory, cheInstallationLocation);
+        new OpenShiftStopWorkspaceRoleProvisioner(clientFactory, cheInstallationLocation, true);
     lenient().when(clientFactory.createOC()).thenReturn(osClient);
     lenient().when(osClient.roles()).thenReturn(mixedRoleOperation);
     lenient().when(osClient.roleBindings()).thenReturn(mixedRoleBindingOperation);
@@ -190,5 +190,29 @@ public class OpenShiftStopWorkspaceRoleProvisionerTest {
     verify(osClient.roleBindings()).inNamespace("developer-che");
     verify(osClient.roleBindings().inNamespace("developer-che"))
         .createOrReplace(expectedRoleBinding);
+  }
+
+  @Test
+  public void shouldNotCreateRoleBindingWhenStopWorkspaceRolePropertyIsDisabled()
+      throws InfrastructureException {
+    OpenShiftStopWorkspaceRoleProvisioner disabledStopWorkspaceRoleProvisioner =
+        new OpenShiftStopWorkspaceRoleProvisioner(clientFactory, cheInstallationLocation, false);
+    disabledStopWorkspaceRoleProvisioner.provision("developer-che");
+    verify(osClient, never()).roles();
+    verify(osClient, never()).roleBindings();
+    verify(osClient.roleBindings(), never()).inNamespace("developer-che");
+  }
+
+  @Test
+  public void shouldNotCreateRoleBindingWhenInstallationLocationIsNull()
+      throws InfrastructureException {
+    lenient().when(cheInstallationLocation.getInstallationLocationNamespace()).thenReturn(null);
+    OpenShiftStopWorkspaceRoleProvisioner
+        stopWorkspaceRoleProvisionerWithoutValidInstallationLocation =
+            new OpenShiftStopWorkspaceRoleProvisioner(clientFactory, cheInstallationLocation, true);
+    stopWorkspaceRoleProvisionerWithoutValidInstallationLocation.provision("developer-che");
+    verify(osClient, never()).roles();
+    verify(osClient, never()).roleBindings();
+    verify(osClient.roleBindings(), never()).inNamespace("developer-che");
   }
 }


### PR DESCRIPTION
 Adding 'che.workspace.stop.role.enabled' property in order to have a possibility to disable the 'OpenShiftStopWorkspaceRoleProvisioner'
